### PR TITLE
Update README to include sqlite3 gem dependency information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ For encryption and RSA key generation
 sudo apt-get install openssl
 ```
 
+For the sqlite3 gem
+```bash
+sudo apt-get install libsqlite3-dev
+```
+
 
 # Credits
 [Icon by Google](https://www.google.com/design/icons/)


### PR DESCRIPTION
Upon attempting to install gem dependencies, the `sqlite3` gem may fail to install because `libsqlite3-dev` is missing.
